### PR TITLE
Instantiate utemplate lazily, when it's really used.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='picoweb',
-      version='0.8',
+      version='0.8.1',
       description="""A very lightweight, memory-efficient async web framework
 for MicroPython.org and its uasyncio module.""",
       url='https://github.com/pfalcon/picoweb',
@@ -10,4 +10,6 @@ for MicroPython.org and its uasyncio module.""",
       author_email='pfalcon@users.sourceforge.net',
       license='MIT',
       packages=['picoweb'],
-      install_requires=['micropython-uasyncio', 'micropython-errno', 'micropython-time', 'utemplate'])
+      # Note: no explicit dependency on 'utemplate', if a specific app uses
+      # templates, it must depend on it.
+      install_requires=['micropython-uasyncio', 'micropython-errno', 'micropython-time'])


### PR DESCRIPTION
This allows to e.g. write REST servers which doesn't use templates, and
save memory on importing unused module. Also, don't even depend on
utemplates to minimize "on-disk" application footprint either for such
cases. Applications which do use template should depend on utemplates
themselves.
