### PR TITLE
Allow serving of GZIP version of content from static source

### DIFF
--- a/example_webapp_gzip.py
+++ b/example_webapp_gzip.py
@@ -25,5 +25,5 @@ import logging
 logging.basicConfig(level=logging.INFO)
 #logging.basicConfig(level=logging.DEBUG)
 
-app = picoweb.WebApp(__name__, ROUTES)
+app = picoweb.WebApp(None, routes=ROUTES,gzip_ext='.gz')
 app.run(debug=True)


### PR DESCRIPTION
For example we might want to include bootstrap or Jquery (mobile even) in our project so we can have a nice UI that truly works offline (or when the internet drops out/unavailable).
On the ESP8266 it is particularly slow to server content and most likely serving 100kb or so will cause it to fail, quite easily the same content can be GZIPPED and the browser will use it happily but for JS/CSS we'll transfer 1/4 of the content making it much faster and less likely to cause ENOMEM.

-Enabled the WebApp to check for .gz with minimal of extra code, using
the try/catch so it doesn’t rely on os.path which may not exist
-Renamed ‘import re’ to ‘import ure as re’ as the example web app
didn’t run locally if you only have ure.

![screen shot 2017-01-18 at 3 02 19 pm](https://cloud.githubusercontent.com/assets/1016050/22050456/26289d0a-dd8f-11e6-8e2d-54e7e5c463c8.png)