### PR TITLE
Develop

### DIFF
--- a/picoweb/__init__.py
+++ b/picoweb/__init__.py
@@ -34,10 +34,10 @@ def sendstream(writer, f):
         yield from writer.awrite(buf, 0, l)
 
 
-def jsonify(writer, dict):
+def jsonify(writer, data, status="200", headers=None):
     import ujson
-    yield from start_response(writer, "application/json")
-    yield from writer.awrite(ujson.dumps(dict))
+    yield from start_response(writer, content_type="application/json", status=status, headers=headers)
+    yield from writer.awrite(ujson.dumps(data))
 
 def start_response(writer, content_type="text/html", status="200", headers=None):
     yield from writer.awrite("HTTP/1.0 %s NA\r\n" % status)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sdist_upip
 
 
 setup(name='picoweb',
-      version='1.4.1',
+      version='1.4.2',
       description="A very lightweight, memory-efficient async web framework \
 for MicroPython.org and its uasyncio module.",
       long_description=open('README.rst').read(),


### PR DESCRIPTION
Hi,

I've slightly extended the `jsonify` function to allow setting status code and headers. 

This simplifies returning documented error responses in REST APIs such as: 

`yield from picoweb.jsonify(resp, {'error': 'invalid value: %s' %  arg}, status=400)`

I've also renamed the `jsonify` original parameter from `dict` to `data` since:
- `dict` is a reserved name somehow
- the data are not always a dict (they can be a list too for instance)