### PR TITLE
Add a way to start the server in an external event loop.

### DIFF
--- a/example_webapp3.py
+++ b/example_webapp3.py
@@ -1,0 +1,34 @@
+#
+# This is a picoweb example showing a web page route
+# specification using view decorators (Flask style)
+# with an external asyncio event loop.
+#
+import logging
+import picoweb
+import uasyncio as asyncio
+
+app = picoweb.WebApp(__name__)
+
+@app.route("/")
+def index(req, resp):
+    yield from picoweb.start_response(resp)
+    yield from resp.awrite("I can show you a table of <a href='squares'>squares</a>.\r\n")
+
+@app.route("/squares")
+def squares(req, resp):
+    yield from picoweb.start_response(resp)
+    yield from resp.awrite("Oh well, I lied\r\n")
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("picoweb")
+
+print("creating server task")
+app_server = app.get_server(debug = True, host = "0.0.0.0", port = 80, log = log)
+loop = asyncio.get_event_loop()
+loop.create_task(asyncio.start_server(*app_server))
+
+print("run_forever()")
+try:
+    loop.run_forever()
+except KeyboardInterrupt:
+    loop.close()

--- a/picoweb/__init__.py
+++ b/picoweb/__init__.py
@@ -308,3 +308,21 @@ class WebApp:
             print("* Running on http://%s:%s/" % (host, port))
         self.serve(loop, host, port)
         loop.close()
+
+    def get_server(self, host="127.0.0.1", port=8081, debug=False, lazy_init=False, log=None):
+        # Method to get a server task that can be used to start the picoweb
+        # server in an external asyncio loop.
+        if log is None and debug >= 0:
+            import ulogging
+            log = ulogging.getLogger("picoweb")
+            if debug > 0:
+                log.setLevel(ulogging.DEBUG)
+        self.log = log
+        gc.collect()
+        self.debug = int(debug)
+        self.init()
+        if not lazy_init:
+            for app in self.mounts:
+                app.init()
+
+        return (self._handle, host, port)


### PR DESCRIPTION
New method get_server(...) has the same arguments as run,
but returns a tuple of (_handle, host, port), which can
be used to add the picoweb server to an existing asyncio
event loop with loop.create_task(asyncio.start_server(*t)).